### PR TITLE
Reimplement Miro career ladder diagram as Mermaid diagram

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,66 @@ It's the anchor point used through all of our feedback and promotion cycles. Thi
 
 ## Career Ladder
 
-![Ladder Diagram](ladder.jpg)
+```mermaid
+flowchart BT
+    TD[Technical Director]
+    PA[Principal Architect]
+    EM[Engineering Manager]
+    CEM[Cloud Engineering Manager]
+    QAM[QA/QE Manager]
+    PE[Principal Engineer]
+    LE[Lead Engineer]
+    SE[Senior Engineer]
+    E[Engineer]
+    GE[Graduate Engineer]
+    PCE[Principal Cloud Engineer]
+    LCE[Lead Cloud Engineer]
+    SCE[Senior Cloud Engineer]
+    CE[Cloud Engineer]
+    GCE[Graduate Cloud Engineer]
+    PAE[Principal Automation Engineer]
+    LQE[Lead QA/QE Engineer]
+    SQE[Senior QA/QE Engineer]
+    QE[QA/QE Engineer]
+    GQE[Graduate QA/QE Engineer]
+    
+    PA --> TD
+    EM --> TD
+    CEM --> TD
+    QAM --> TD
+    PE .-> PA
+    LE --> EM
+    PCE .-> PA
+    LCE --> CEM
+    LQE .-> QAM
+    subgraph sube[Engineering]
+        subgraph subsl[Stream Lead Capable Positions]
+            SE .-> PE
+            SE .-> LE
+        end
+        E .-> SE
+        GE .-> E
+    end
+    subgraph subc[Cloud]
+        SCE .-> PCE
+        SCE .-> LCE
+        CE .-> SCE
+        GCE .-> CE
+    end
+    subgraph subq[QA/QE]
+        SQE .-> PAE
+        SQE .-> LQE
+        QE .-> SQE
+        GQE .-> QE
+    end
+    PAE .-> subc
+    
+    subgraph Key
+        direction LR
+        A[ ] --> B[Reports To]
+        C[ ] .-> D[Career Pathway]
+    end
+```
 
 ## Contributions
 


### PR DESCRIPTION
As a proposal, replacing the .jpg career ladder with a mermaid one. 
Lots of pros/cons each way, this is to open the conversation. 
Some Pros
- Keeps the content in the repo, anyone can contribute.
- Automatic layout, less effort to maintain.
- We can do other neat things like turn the roles into hyperlinks
Cons
-Less easy to control layout explicitly
   -The Principal Automation Engineer .-> Cloud flow forces the QA subgraph to be positioned lower than it would be, which isn't ideal.

[Link to preview changes](https://github.com/loanmarket/career-ladder/blob/339711d53f4c86f4e1128c129cad357e8deec6aa/README.md)

[Mermaid documenation](https://mermaid-js.github.io/mermaid/#/flowchart?id=subgraphs)